### PR TITLE
Add Windows 2019 Core

### DIFF
--- a/roles/setup/templates/VirtualBox.vbox.tmpl
+++ b/roles/setup/templates/VirtualBox.vbox.tmpl
@@ -49,9 +49,5 @@
     <StorageControllers>
       <StorageController name="SATA" type="AHCI" PortCount="5" useHostIOCache="true" Bootable="true" IDE0MasterEmulationPort="0" IDE0SlaveEmulationPort="1" IDE1MasterEmulationPort="2" IDE1SlaveEmulationPort="3"/>
     </StorageControllers>
-    <VRDEProperties>
-      <Property name="TCP/Address" value="{{ virtualbox.vrde_host }}"/>
-      <Property name="TCP/Ports" value="{{ virtualbox.vrde_port }}"/>
-    </VRDEProperties>
   </Machine>
 </VirtualBox>


### PR DESCRIPTION
Adds a configuration to build Windows Server 2019 Core. Tested in my own VirtualBox environment, unsure of other environments but the steps used don't differ greatly from the steps used in other environments.

You'll see a reference to headless mode (which I used during debug). I'll raise an issue for that since it could be helpful too.