### PR TITLE
New image release

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,5 +1,15 @@
 # This generates CHANGELOG.md and changelog entries in the box description
 changelog:
+- version: '1.1.0'
+  date: 2022-05-19
+  changes:
+  - Update the `PSReadLine`, `PowerShellGet`, and `PackageManagement` modules to the latest version
+  - Set certificate used for CredSSP over WinRM to be the same one used for the HTTPS listener.
+  - Updated OpenSSH version to [v8.9.1.0p1-Beta](https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.9.1.0p1-Beta).
+  - Updated VirtIO driver version to `0.1.215-2`.
+  host_specific_changes:
+    '2022':
+    - Used new ISO with latest updates
 - version: '1.0.0'
   date: 2021-06-19
   changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ changelog entries to `roles/packer-setup/vars/main.yml` to modify this file_
 This is the changelog of each image version uploaded to the Vagrant Cloud. It
 contains a list of changes that each incorporate.
 
+### v1.1.0 - 2022-05-19
+
+* Update the `PSReadLine`, `PowerShellGet`, and `PackageManagement` modules to the latest version
+* Set certificate used for CredSSP over WinRM to be the same one used for the HTTPS listener.
+* Updated OpenSSH version to [v8.9.1.0p1-Beta](https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.9.1.0p1-Beta).
+* Updated VirtIO driver version to `0.1.215-2`.
+* 2022
+    * Used new ISO with latest updates
+
 ### v1.0.0 - 2021-06-19
 
 * Removed Packer as part of the build process, this runs using Ansible only.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ _Note: This repo used to use Packer to build the Vagrant images (hence the name)
 To use the scripts in this repo you will need the following;
 
 * [Ansible](https://github.com/ansible/ansible) >= 2.9.0
-* `mkisofs`
-* `pigz`
+* `mkisofs` to build the bootstrapping iso for Windows
+* `pigz` to compress the resulting Vagrant box image
 
 The following Python libraries are also used:
 
 * [httpx](https://pypi.org/project/httpx/)
+* [psutil](https://pypi.org/project/psutil/)
 * [pypsrp](https://pypi.org/project/pypsrp/)
 * [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/) to retrieve the latest Windows Updates for the build
 
@@ -49,12 +50,19 @@ sudo apt-get install mkisofs pigz
 sudo yum install mkisofs pigz
 
 # for Fedora
-sudo dnf install mkisofs pigz
+sudo dnf install genisoimage pigz
 
 # for MacOS (requires Homebrew)
 brew install cdrtools pigz
 ```
 
+The Ansible requirements can be installed with
+
+```bash
+pip install -r requirements.txt
+ansible-galaxy role install -r requirements.yml -p roles
+ansible-galaxy collection install -r requirements.yml -p collections
+```
 
 ## How to Run
 
@@ -62,7 +70,7 @@ The imaging process uses Ansible from start to finish and in most cases can be r
 To start the process run the following script:
 
 ```bash
-ansible-playbook main.yml --limit '*2022'`
+ansible-playbook main.yml --limit '*2022'
 ```
 
 This will build the Windows Server 2022 image for QEMU.
@@ -70,6 +78,7 @@ You can change `*2022` to the Windows version as defined in inventory.yml that y
 The following options can also be specified with `-e` to change the build behaviour:
 
 * `platform`: The Hypervisor to build for - can be `qemu`, `virtualbox`, or `hyperv` (default: `qemu`).
+* `headless`: Dont't display the VM console during the build process (default: `true`)
 * `output_dir`: The base directory to store the output/build files (default: `{{ playbook_dir }}/output`).
 * `setup_username`: The name of the user to create on the base image
 * `setup_password`: The password to apply to the username that is created.

--- a/collections/ansible_collections/jborean93/windoze/plugins/module_utils/update_catalog.py
+++ b/collections/ansible_collections/jborean93/windoze/plugins/module_utils/update_catalog.py
@@ -39,7 +39,7 @@ except ImportError:
 
 
 CATALOG_URL = 'https://www.catalog.update.microsoft.com/'
-DOWNLOAD_PATTERN = re.compile(r'\[(\d*)\]\.url = [\"\'](http[s]?://w{0,3}.?download\.windowsupdate\.com/[^\'\"]*)')
+DOWNLOAD_PATTERN = re.compile(r'\[(\d*)\]\.url = [\"\'](http[s]?://.*download\.windowsupdate\.com/[^\'\"]*)')
 PRODUCT_SPLIT_PATTERN = re.compile(r',(?=[^\s])')
 
 
@@ -72,6 +72,7 @@ async def _invoke_request(
     # The update catalog is crazy unstable and can comsetimes return an error, no response, something else. Instead we
     # just try the request multiple times until it works. Not great but I don't have time to find out a better way.
     failed_once = False
+    attempt = 0
 
     while True:
         try:
@@ -84,7 +85,11 @@ async def _invoke_request(
                 # I found that if it fails at least once adding a sleep between attempts helps.
                 await asyncio.sleep(1)
 
+            if attempt > 9:
+                raise
+
             failed_once = True
+            attempt += 1
 
 
 async def _get_update_details(

--- a/inventory.yml
+++ b/inventory.yml
@@ -77,17 +77,17 @@ all:
         '2022':
           box_tag: jborean93/WindowsServer2022
 
-          iso_src: https://software-download.microsoft.com/download/sg/20348.1.210507-1500.fe_release_SERVER_EVAL_x64FRE_en-us.iso
-          iso_checksum: sha256:2ee3a0325f7230b1ff68bd8db2695f4102eae4ff32118382b1ab2e2b98a71aaa
+          iso_src: https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso
+          iso_checksum: sha256:3e4fa6d8507b554856fc9ca6079cc402df11a8b79344871669f0251535255325
           iso_wim_label: Windows Server 2022 SERVERSTANDARD
           architecture: amd64
-          driver_host_string: 2k19  # FUTURE: update once virtio does
+          driver_host_string: 2k22
 
-          updates:  # FUTURE: This might have changed, look into once more updates are available
-            product: Windows Server 2022
+          updates:
+            product: Microsoft Server operating system-21H2
             names:
-            - Servicing Stack Update for Windows Server 2022
-            - Cumulative Update for Windows Server 2022
+            - Servicing Stack Update for Microsoft server operating system version 21H2
+            - Cumulative Update for Microsoft server operating system version 21H2
 
           virtualbox:
             os_type: Windows2019_64  # FUTURE: update once virtualbox does
@@ -110,7 +110,8 @@ all:
   vars:
     output_dir: '{{ playbook_dir }}/output'
     platform: qemu
-    openssh_version: V8.6.0.0p1-Beta
-    virtio_version: 0.1.185-2
+    openssh_version: v8.9.1.0p1-Beta
+    # FUTURE: Update once https://github.com/virtio-win/kvm-guest-drivers-windows/issues/769 is fixed
+    virtio_version: 0.1.215-2
     setup_username: vagrant
     setup_password: vagrant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4
 httpx
+psutil
 pypsrp

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 roles:
 - src: jborean93.win_openssh
-  version: v0.3.0
+  version: v0.3.2
 
 collections:
 - name: ansible.windows

--- a/roles/personalise/tasks/main.yml
+++ b/roles/personalise/tasks/main.yml
@@ -129,6 +129,7 @@
       if ($pwsh) {
           (New-Object -ComObject Scripting.FileSystemObject).GetFile($pwsh.Path).ShortPath
       }
+    changed_when: False
     register: pri_personalize_pwsh_path
     retries: 5  # Found intermittent errors here, just try a few times - might need to replace the COM side.
     delay: 5
@@ -137,6 +138,120 @@
   - name: set output fact for OpenSSH to use for pwsh subsystem path
     set_fact:
       out_personalize_pwsh_path: '{{ pri_personalize_pwsh_path.stdout | trim }}'
+
+- name: module updates for PowerShell Pre 5.1
+  when:
+  - inventory_hostname in ['win-2012', 'win-2012r2']
+  block:
+  - name: install PowerShellGet, PackageManagement
+    ansible.windows.win_powershell:
+      script: |
+        [CmdletBinding()]
+        param()
+
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        $moduleDir = Join-Path -Path $env:ProgramFiles -ChildPath (Join-Path -Path "WindowsPowerShell" -ChildPath "Modules")
+        if (-not (Test-Path -LiteralPath $moduleDir)) {
+            New-Item -Path $moduleDir -ItemType Directory | Out-Null
+            $Ansible.Changed = $true
+        }
+
+        foreach ($package in @("PowerShellGet", "PackageManagement")) {
+            $targetDir = Join-Path -Path $moduleDir -ChildPath $package
+            if (Test-Path -LiteralPath $targetDir) {
+                continue
+            }
+            $Ansible.Changed = $true
+
+            $searchUri = 'https://www.powershellgallery.com/api/v2/Packages?$filter=Id eq ''{0}'' and IsLatestVersion' -f $package
+            $res = Invoke-RestMethod -Uri $searchUri
+            $sourceUri = $res.Content.src
+            $moduleTmp = Join-Path -Path $Ansible.Tmpdir -ChildPath $package
+            New-Item -Path $moduleTmp -ItemType Directory | Out-Null
+
+            $moduleZip = Join-Path -Path $moduleTmp -ChildPath "$package.zip"
+            (New-Object -TypeName System.Net.WebClient).DownloadFile($sourceUri, $moduleZip)
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($moduleZip, $moduleTmp)
+
+            New-Item -Path $targetDir -ItemType Directory | Out-Null
+            Copy-Item -Path (Join-Path -Path $moduleTmp -ChildPath "*") -Destination $targetDir -Recurse
+
+            # Remove some extra files that would be in the npkg
+            Remove-Item -LiteralPath (Join-Path -Path $targetDir -ChildPath "$package.zip") -Force -Recurse
+            Remove-Item -LiteralPath (Join-Path -Path $targetDir -ChildPath "$package.nuspec") -Force -Recurse
+            Remove-Item -LiteralPath (Join-Path -Path $targetDir -ChildPath "[Content_Types].xml") -Force -Recurse
+            Remove-Item -LiteralPath (Join-Path -Path $targetDir -ChildPath "_rels") -Force -Recurse
+            Remove-Item -LiteralPath (Join-Path -Path $targetDir -ChildPath "package") -Force -Recurse
+        }
+
+  # This is the latest version that is available for PowerShell pre 5.1
+  - name: install PSReadLine 1.2
+    ansible.windows.win_powershell:
+      script: |
+        [CmdletBinding()]
+        param()
+
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        if (-not (Get-Module -Name PSReadLine -ListAvailable)) {
+            Install-Module -Name PSReadLine -RequiredVersion '1.2' -Force
+            $Ansible.Changed = $true
+        }
+    # Remove once 2012 is gone
+    environment:
+      PSModulePath: C:\Program Files\WindowsPowerShell\Modules
+
+- name: module updates for PowerShell 5.1
+  when:
+  - inventory_hostname not in ['win-2012', 'win-2012r2']
+  block:
+  - name: install newer versions of PowerShellGet, PackageManagement, and PSReadLine
+    ansible.windows.win_powershell:
+      script: |
+        [CmdletBinding()]
+        param()
+
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        # Needed for Server 2016
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+        if (-not (Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) {
+            Install-PackageProvider -Name NuGet -Force -ForceBootstrap | Out-Null
+            $Ansible.Changed = $true
+        }
+
+        foreach ($package in @("PackageManagement", "PowerShellGet", "PSReadLine")) {
+            $latestVersion = Find-Module -Name $package -AllVersions -ErrorAction SilentlyContinue |
+                Sort-Object -Property Version -Descending |
+                Select-Object -ExpandProperty Version -First 1
+            $installedVersions = Get-Module -Name $package -ListAvailable
+
+            $installed = $installedVersions | Where-Object Version -eq $latestVersion
+            if ($installed) {
+                continue
+            }
+
+            Install-Module -Name $package -Force
+            $Ansible.Changed = $true
+
+            # Output for the next task to remove
+            $installedVersions.ModuleBase
+        }
+    register: pri_personalize_pwsh_packages
+
+  # This needs to be done in a separate process as the above would have loaded some dlls and locked the dir
+  - name: remove older versions of PowerShellGet, PackageManagement, and PSReadLine
+    win_file:
+      path: '{{ item }}'
+      state: absent
+    with_items: '{{ pri_personalize_pwsh_packages.output }}'
 
 - name: install the VirtualBox Guest Additions
   include_tasks: virtualbox.yml

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -60,7 +60,16 @@
   get_url:
     url: https://www.microsoft.com/pki/certs/MicrosoftCodeVerifRoot.crt
     dest: '{{ output_dir }}/common/MicrosoftCodeVerifRoot.crt'
+    checksum: sha256:ca7791d5c9a1580dcdcad31d0549fea2043e229aa4f4932cfa056ca23eb8a950
   register: verif_root_cert
+  run_once: True
+
+- name: download latest VeriSign universal root for VirtIO signed devices
+  get_url:
+    url: https://symantec.tbs-certificats.com/vsign-universal-root.crt
+    dest: '{{ output_dir }}/common/VeriSignUniversalRoot.crt'
+    checksum: sha256:2de340400722f15d90e11b08cf9f3bfaa7f15eca7151f5a9c3eb8e7a6588da30
+  register: verisign_root_cert
   run_once: True
 
 - name: download Virtio ISO
@@ -149,8 +158,10 @@
     -o {{ secondary_iso_src | quote }}
     {{ (output_dir ~ '/' ~ inventory_hostname ~ '/iso') | quote }}
     {{ (output_dir ~ '/common/MicrosoftCodeVerifRoot.crt') | quote }}
+    {{ (output_dir ~ '/common/VeriSignUniversalRoot.crt') | quote }}
   when: >-
     verif_root_cert is changed or
+    verisign_root_cert is changed or
     (inventory_hostname == '2012' and wmf3_hotfix is changed) or
     downloaded_updates is changed or
     iso_template_files is changed

--- a/roles/setup/tasks/qemu.yml
+++ b/roles/setup/tasks/qemu.yml
@@ -43,7 +43,7 @@
       -m 2048M
       -vga qxl
       -display {{ headless | ternary('none', 'gtk') }}
-      -spice port={{ (guest_port | int) + 1 }},addr=127.0.0.1,disable-ticketing
+      -spice port={{ (guest_port | int) + 1 }},addr=127.0.0.1,disable-ticketing=on
       -device virtio-serial-pci
       -device virtserialport,chardev=spicechannel{{ inventory_hostname }}0,name=com.redhat.spice.0
       -chardev spicevmc,id=spicechannel{{ inventory_hostname }}0,name=vdagent

--- a/roles/setup/templates/bootstrap.ps1.tmpl
+++ b/roles/setup/templates/bootstrap.ps1.tmpl
@@ -61,14 +61,20 @@ Function Get-VirtIODriverPath {
     param (
         [Parameter(Mandatory)]
         [String]
-        $Name
+        $Name,
+
+        [Parameter()]
+        [String]
+        $HostKey
     )
 
-    $hostKey = '{{ driver_host_string }}'
+    if (-not $HostKey) {
+        $HostKey = '{{ driver_host_string }}'
+    }
     $architecture = $env:PROCESSOR_ARCHITECTURE
 
     Get-PSDrive -PSProvider FileSystem | ForEach-Object -Process {
-        Get-ChildItem -LiteralPath "$($_.Root)\$Name\$hostKey\$architecture" -Filter '*.inf' -ErrorAction SilentlyContinue
+        Get-ChildItem -LiteralPath "$($_.Root)\$Name\$HostKey\$architecture" -Filter '*.inf' -ErrorAction SilentlyContinue
     } | Select-Object -First 1 -ExpandProperty FullName
 }
 
@@ -101,6 +107,63 @@ Function Import-Certificate {
     }
 }
 
+Function Install-Driver {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Path
+    )
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PackerWindoze
+{
+    public class NativeMethods
+    {
+        [DllImport("Newdev.dll", EntryPoint = "DiInstallDriverW", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool NativeDiInstallDriverW(
+            IntPtr hwndParent,
+            string InfPath,
+            UInt32 Flags,
+            out bool NeedReboot);
+
+        public static bool DiInstallDriverW(string infPath)
+        {
+            bool needsReboot;
+            if (!NativeDiInstallDriverW(IntPtr.Zero, infPath, 0, out needsReboot))
+            {
+                int err = Marshal.GetLastWin32Error();
+                if (err != 0x00000103)  // Is returned if the driver is already present
+                    throw new Win32Exception(err);
+                else
+                    needsReboot = false;
+            }
+
+            return needsReboot;
+        }
+    }
+}
+'@
+
+    $certDir = Split-Path -Path $Path -Parent
+    $catPath = Get-ChildItem -Path $certDir -Filter '*.cat' -File
+    $driverCert = (Get-AuthenticodeSignature -LiteralPath $catPath.FullName).SignerCertificate
+    if ($driverCert) {
+        Import-Certificate -Cert $driverCert -Store TrustedPublisher
+    }
+
+    Write-Log -Message "Installing driver at '$Path'"
+    [PackerWindoze.NativeMethods]::DiInstallDriverW($Path)
+}
+
 $tmpdir = 'C:\Windows\TEMP'
 Write-Log -Message "Starting bootstrap.ps1 with action '$Action'"
 
@@ -108,75 +171,115 @@ $bootstrapActions = @(
 {% if inventory_hostname == '2012' %}
 {# 2012 comes with pwsh v3 which requires a once off hostfix #}
     @{
-        Name = 'WMFv3 Memory Hotfix'
-        File = 'KB2842230-wmfv3.zip'
+        Name           = 'WMFv3 Memory Hotfix'
+        File           = 'KB2842230-wmfv3.zip'
         ZipFilePattern = '*KB2842230*.msu'
-        Action = 'install'
+        Action         = 'install'
     },
 {% endif %}
 {% for update in update_files | default([]) %}
     @{
-        Name = '{{ update.title }}'
-        File = '{{ update.filename }}'
+        Name   = '{{ update.title }}'
+        File   = '{{ update.filename }}'
         Action = 'install'
     },
 {% endfor %}
 {% if platform in ['qemu', 'virtualbox'] %}
     @{
-        Name = "Red Hat Virtio Network Driver"
-        Path = (Get-VirtIODriverPath -Name NetKVM)
+        Name   = "Red Hat Virtio Network Driver"
+        Path   = (Get-VirtIODriverPath -Name NetKVM)
         Action = "driver"
     }
 {% endif %}
 {% if platform == 'qemu' %}
     @{
-        Name = "Red Hat Virtio SCSI driver"
-        Path = (Get-VirtIODriverPath -Name vioscsi)
+        Name   = "Red Hat Virtio Memory Memory Balloon Driver"
+        Path   = (Get-VirtIODriverPath -Name Balloon)
         Action = "driver"
     },
+{% if inventory_hostname != '2012' %}
+{# FUTURE: VirtIO has invalid metadata for this with 2012 #}
     @{
-        Name = "Red Hat Virtio RNG driver"
-        Path = (Get-VirtIODriverPath -Name viorng)
+        Name   = "Red Hat Virtio FwCfg"
+        Path   = (Get-VirtIODriverPath -Name fwcfg)
         Action = "driver"
     },
+{% endif %}
     @{
-        Name = "Red Hat Virtio serial driver"
-        Path = (Get-VirtIODriverPath -Name vioserial)
-        Action = "driver"
-    },
-    @{
-        Name = "Red Hat Virtio Memory Memory Balloon Driver"
-        Path = (Get-VirtIODriverPath -Name Balloon)
-        Action = "driver"
-    },
-    @{
-        Name = "Red Hat Virtio pvpanic driver"
-        Path = (Get-VirtIODriverPath -Name pvpanic)
-        Action = "driver"
-    },
-    @{
-        Name = "Red Hat Virtio Graphics Driver"
-        Path = (Get-VirtIODriverPath -Name qxldod)
-        Action = "driver"
-    },
-    @{
-        Name = "Red Hat Virtio VIOInput driver"
-        Path = (Get-VirtIODriverPath -Name vioinput)
-        Action = "driver"
-    },
-    @{
-        Name = "Red Hat Virtio PCI serial"
-        Path = (Get-VirtIODriverPath -Name qemupciserial)
+        Name   = "Red Hat Virtio pvpanic driver"
+        Path   = (Get-VirtIODriverPath -Name pvpanic)
         Action = "driver"
     },
 {% if inventory_hostname not in ['2012', '2012r2'] %}
 {# qemufwcfg only valid for 2016+ #}
     @{
-        Name = "Red Hat Virtio Firmware Config Driver"
-        Path = (Get-VirtIODriverPath -Name qemufwcfg)
+        Name   = "Red Hat Virtio Firmware Config Driver"
+        Path   = (Get-VirtIODriverPath -Name qemufwcfg)
         Action = "driver"
     },
 {% endif %}
+    @{
+        Name   = "Red Hat Virtio PCI serial"
+        Path   = (Get-VirtIODriverPath -Name qemupciserial)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio Graphics Driver"
+        # FUTURE: Remove -HostKey once 2k22 support is in virtio
+        Path   = (Get-VirtIODriverPath -Name qxldod{{ ' -HostKey 2k19' if inventory_hostname == '2022' else '' }})
+        Action = "driver"
+    },
+{% if inventory_hostname in ['2022'] %}
+{# qemufwcfg only valid for 2022 #}
+    @{
+        Name   = "Red Hat Virtio Q35 SMBus driver"
+        Path   = (Get-VirtIODriverPath -Name smbus)
+        Action = "driver"
+    },
+{% endif %}
+{% if inventory_hostname != '2012' %}
+{# Not available for 2012 #}
+    @{
+        Name   = "Red Hat Virtio SRIOV NetKVM"
+        Path   = (Get-VirtIODriverPath -Name sriov)
+        Action = "driver"
+    },
+{% endif %}
+    @{
+        Name   = "Red Hat Virtio FS"
+        Path   = (Get-VirtIODriverPath -Name viofs)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio GPU DOD"
+        Path   = (Get-VirtIODriverPath -Name viogpudo)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio VIOInput driver"
+        Path   = (Get-VirtIODriverPath -Name vioinput)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio RNG driver"
+        Path   = (Get-VirtIODriverPath -Name viorng)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio SCSI driver"
+        Path   = (Get-VirtIODriverPath -Name vioscsi)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio serial driver"
+        Path   = (Get-VirtIODriverPath -Name vioserial)
+        Action = "driver"
+    },
+    @{
+        Name   = "Red Hat Virtio SCSI controller"
+        Path   = (Get-VirtIODriverPath -Name viostor)
+        Action = "driver"
+    },
 {% endif %}
     @{
         Name = "Configure WinRM"
@@ -250,39 +353,6 @@ for ($i = 0; $i -lt $actualActions.Count; $i++) {
 
         driver {
             Write-Log -Message "Installing driver $($currentAction.Name)"
-            Add-Type -TypeDefinition @'
-using System;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-
-namespace PackerWindoze
-{
-    public class NativeMethods
-    {
-        [DllImport("Newdev.dll", EntryPoint = "DiInstallDriverW", SetLastError = true, CharSet = CharSet.Unicode)]
-        private static extern bool NativeDiInstallDriverW(
-            IntPtr hwndParent,
-            string InfPath,
-            UInt32 Flags,
-            out bool NeedReboot);
-
-        public static bool DiInstallDriverW(string infPath)
-        {
-            bool needsReboot;
-            if (!NativeDiInstallDriverW(IntPtr.Zero, infPath, 0, out needsReboot))
-            {
-                int err = Marshal.GetLastWin32Error();
-                if (err != 0x00000103)  // Is returned if the driver is already present
-                    throw new Win32Exception(err);
-                else
-                    needsReboot = false;
-            }
-
-            return needsReboot;
-        }
-    }
-}
-'@
 
             # Older hosts may not have the root Microsoft cert that has signed the VirtIO drivers installed. We
             # manually install it so we can install the driver silently without user interaction.
@@ -290,27 +360,19 @@ namespace PackerWindoze
             $rootCert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $rootCertPath
             Import-Certificate -Cert $rootCert -Store Root
 
-            $catPath = Get-ChildItem -Path (Split-Path -Path $currentAction.Path -Parent) -Filter '*.cat' -File
-            $driverCert = (Get-AuthenticodeSignature -LiteralPath $catPath.FullName).SignerCertificate
-            if ($driverCert) {
-                Import-Certificate -Cert $driverCert -Store TrustedPublisher
-            }
+            # Hosts also seem to be missing the VeriSign Universal Root Cert used by some VirtIO drivers.
+            # FUTURE: See if this can be removed once updating VirtIO to a newer version
+            $rootCertPath = Join-Path $PSScriptRoot 'VeriSignUniversalRoot.crt'
+            $rootCert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $rootCertPath
+            Import-Certificate -Cert $rootCert -Store Root
 
-            $rebootRequired = [PackerWindoze.NativeMethods]::DiInstallDriverW($currentAction.Path)
+            $rebootRequired = Install-Driver -Name $currentAction.Name -Path $currentAction.Path
             if ($rebootRequired) {
                 Restart-AndResume -Action $nextAction.Name
             }
         }
 
         winrm {
-{% if platform == 'virtualbox' and inventory_hostname == '2022' %}
-{# Bug in NetKVM for Server 2022 - https://github.com/virtio-win/kvm-guest-drivers-windows/issues/583 #}
-            Write-Log -Message "Disabling Offload Tx Checksum for NetKVM adapter"
-            Get-NetAdapter |
-                Where-Object DriverFileName -eq 'netkvm.sys' |
-                Set-NetAdapterAdvancedProperty -RegistryKeyword 'Offload.TxChecksum' -RegistryValue 0
-
-{% endif %}
 {% if platform == 'hyperv' %}
             $ipAddr = '{{ hyperv_ip }}'
             Write-Log -Message "Setting IP address to $ipAddr"

--- a/roles/sysprep/templates/setup.ps1.tmpl
+++ b/roles/sysprep/templates/setup.ps1.tmpl
@@ -71,13 +71,6 @@ switch( $action) {
         Write-Log -Message "Setting the rearm key back to 0 so people in the future can rearm the OS"
         Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform" -Name SkipRearm -Value 0
 
-{% if platform == 'virtualbox' and inventory_hostname == 'win-2022' %}
-{# Bug in NetKVM for Server 2022 - https://github.com/virtio-win/kvm-guest-drivers-windows/issues/583 #}
-        Write-Log -Message "Disabling Offload Tx Checksum for NetKVM adapter"
-        Get-NetAdapter |
-            Where-Object DriverFileName -eq 'netkvm.sys' |
-            Set-NetAdapterAdvancedProperty -RegistryKeyword 'Offload.TxChecksum' -RegistryValue 0
-{% endif %}
         Write-Log -Message "Recreate the WinRM listeners"
         Reset-WinRMConfig -Verbose
 


### PR DESCRIPTION
Updates the provided PSReadLine, PackageManagement, and PowerShellGet
modules. Updates the virt-win drivers to `0.1.215-2`. Ensures the WinRM
CredSSP listener uses the same cert for the WinRM HTTPS endpoint.
Updates the Win32-OpenSSH build to the latest version available. Various
other tweaks along the way.